### PR TITLE
Added System Command handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This OctoPrint plugin controls an ATX/AUX power supply to help reduce power cons
 
 Power supply can be automatically switched on when user specified commands are sent to the printer and/or switched off when idle.
 
-Supports Commands(G-Code) or GPIO to switch power supply on/off.
+Supports Commands (G-Code or System) or GPIO to switch power supply on/off.
 
 **Requires a Raspberry Pi**
 

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -11,6 +11,7 @@ from octoprint.util import RepeatedTimer
 import RPi.GPIO as GPIO
 import time
 import threading
+import os
 
 class PSUControl(octoprint.plugin.StartupPlugin,
                    octoprint.plugin.TemplatePlugin,
@@ -226,17 +227,20 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                     self._start_idle_timer()
 
     def turn_psu_on(self):
-        if self.switchingMethod == 'COMMAND' or self.switchingMethod == 'GPIO':
+        if self.switchingMethod == 'COMMAND' or self.switchingMethod == 'GPIO' or self.switchingMethod == 'SYSTEM':
             self._logger.info("Switching PSU On")
             if self.switchingMethod == 'COMMAND':
                 self._logger.debug("Switching PSU On Using COMMAND: %s" % self.onCommand)
                 self._printer.commands(self.onCommand)
-            elif self.switchingMethod == 'GPIO':
-                self._logger.debug("Switching PSU On Using GPIO: %s" % self.onoffGPIOPin)
-                if not self.invertonoffGPIOPin:
-                    pin_output=GPIO.HIGH
-                else:
-                    pin_output=GPIO.LOW
+            elif self.switchingMethod == 'SYSTEM':
+                 self._logger.debug("Switching PSU On Using SYSTEM: %s" % self.onCommand)
+                 os.system(self.onCommand)
+              elif self.switchingMethod == 'GPIO':
+                   self._logger.debug("Switching PSU On Using GPIO: %s" % self.onoffGPIOPin)
+                   if not self.invertonoffGPIOPin:
+                       pin_output=GPIO.HIGH
+                   else:
+                       pin_output=GPIO.LOW
 
                 try:
                     GPIO.output(self.onoffGPIOPin, pin_output)
@@ -250,22 +254,25 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             self.check_psu_state()
         
     def turn_psu_off(self):
-        if self.switchingMethod == 'COMMAND' or self.switchingMethod == 'GPIO':
+        if self.switchingMethod == 'COMMAND' or self.switchingMethod == 'GPIO' or self.switchingMethod == 'SYSTEM':
             self._logger.info("Switching PSU Off")
             if self.switchingMethod == 'COMMAND':
                 self._logger.debug("Switching PSU Off Using COMMAND: %s" % self.offCommand)
                 self._printer.commands(self.offCommand)
-            elif self.switchingMethod == 'GPIO':
-                self._logger.debug("Switching PSU Off Using GPIO: %s" % self.onoffGPIOPin)
-                if not self.invertonoffGPIOPin:
-                    pin_output=GPIO.LOW
-                else:
-                    pin_output=GPIO.HIGH
+            elif self.switchingMethod == 'SYSTEM':
+                self._logger.debug("Switching PSU Off Using SYSTEM: %s" % self.offCommand)
+                os.system(self.offCommand)
+              elif self.switchingMethod == 'GPIO':
+                    self._logger.debug("Switching PSU Off Using GPIO: %s" % self.onoffGPIOPin)
+                    if not self.invertonoffGPIOPin:
+                        pin_output=GPIO.LOW
+                    else:
+                        pin_output=GPIO.HIGH
 
-                try:
-                    GPIO.output(self.onoffGPIOPin, pin_output)
-                except (RuntimeError, ValueError) as e:
-                    self._logger.error(e)
+                    try:
+                        GPIO.output(self.onoffGPIOPin, pin_output)
+                    except (RuntimeError, ValueError) as e:
+                        self._logger.error(e)
 
             if not self.enableSensing:
                 self._noSensing_isPSUOn = False

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -147,9 +147,6 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         else:
             self.isPSUOn = self._noSensing_isPSUOn
         
-        if self._printer.is_closed_or_error() == False:
-            self.isPSUOn = True
-	
         self._logger.debug("isPSUOn: %s" % self.isPSUOn)
 
         if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -147,6 +147,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         else:
             self.isPSUOn = self._noSensing_isPSUOn
         
+        if self._printer.is_closed_or_error() == False:
+            self.isPSUOn = True
+	
         self._logger.debug("isPSUOn: %s" % self.isPSUOn)
 
         if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -338,7 +338,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.onGCodeCommand = self._settings.get(["onGCodeCommand"])
         self.offGCodeCommand = self._settings.get(["offGCodeCommand"])
         self.onSysCommand = self._settings.get(["onSysCommand"])
-        self.offSysCommand = self._settings.get(["offGCodeCommand"])
+        self.offSysCommand = self._settings.get(["offSysCommand"])
         self.enableSensing = self._settings.get_boolean(["enableSensing"])
         self.senseGPIOPin = self._settings.get_int(["senseGPIOPin"])
         self.autoOn = self._settings.get_boolean(["autoOn"])

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -25,8 +25,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.invertonoffGPIOPin = False
         self.onGCodeCommand = ''
         self.offGCodeCommand = ''
-	self.onSysCommand = ''
-	self.offSysCommand = ''
+	    self.onSysCommand = ''
+	    self.offSysCommand = ''
         self.autoOn = False
         self.autoOnCommands = ''
         self.autoOnCommandsArray = []
@@ -36,6 +36,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.idleIgnoreCommandsArray = []
         self.idleTimeoutWaitTemp = 0
         self.enableSensing = False
+        self.assumeOnIfConnected = False
         self.senseGPIOPin = 0
         self.isPSUOn = False
         self._noSensing_isPSUOn = False
@@ -68,6 +69,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
 	
         self.enableSensing = self._settings.get_boolean(["enableSensing"])
         self._logger.debug("enableSensing: %s" % self.enableSensing)
+        
+        self.assumeOnIfConnected = self._settings.get_boolean(["assumeOnIfConnected"])
+        self._logger.debug("assumeOnIfConnected: %s" % self.assumeOnIfConnected)
 
         self.senseGPIOPin = self._settings.get_int(["senseGPIOPin"])
         self._logger.debug("senseGPIOPin: %s" % self.senseGPIOPin)
@@ -118,8 +122,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         
         if self.switchingMethod == 'COMMAND':
             self._logger.info("Using Commands for On/Off")
-	elif self.switchingMethod == 'SYSTEM':
-	    self._logger.info("Using System Commands for On/Off")
+	    elif self.switchingMethod == 'SYSTEM':
+	        self._logger.info("Using System Commands for On/Off")
         elif self.switchingMethod == 'GPIO':
             self._logger.info("Using GPIO for On/Off")
             self._logger.info("Configuring GPIO for pin %s" % self.onoffGPIOPin)
@@ -147,6 +151,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         else:
             self.isPSUOn = self._noSensing_isPSUOn
         
+        if self.assumeOnIfConnected: and self._printer.is_closed_or_error() == False:
+            self.isPSUOn = True
+
         self._logger.debug("isPSUOn: %s" % self.isPSUOn)
 
         if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:
@@ -315,6 +322,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             onSysCommand = '',
             offSysCommand = '',
             enableSensing = False,
+            assumeOnIfConnected = False,
             senseGPIOPin = 0,
             autoOn = False,
             autoOnCommands = "G0,G1,G2,G3,G10,G11,G28,G29,G32,M104,M109,M140,M190",
@@ -340,6 +348,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.onSysCommand = self._settings.get(["onSysCommand"])
         self.offSysCommand = self._settings.get(["offSysCommand"])
         self.enableSensing = self._settings.get_boolean(["enableSensing"])
+        self.assumeOnIfConnected = self._settings.get_boolean(["assumeOnIfConnected"])
         self.senseGPIOPin = self._settings.get_int(["senseGPIOPin"])
         self.autoOn = self._settings.get_boolean(["autoOn"])
         self.autoOnCommands = self._settings.get(["autoOnCommands"])

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -151,7 +151,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         else:
             self.isPSUOn = self._noSensing_isPSUOn
         
-        if self.assumeOnIfConnected: and self._printer.is_closed_or_error() == False:
+        if self.assumeOnIfConnected and self._printer.is_closed_or_error() == False:
             self.isPSUOn = True
 
         self._logger.debug("isPSUOn: %s" % self.isPSUOn)

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -110,6 +110,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         
         if self.switchingMethod == 'COMMAND':
             self._logger.info("Using Commands for On/Off")
+	elif self.switchingMethod == 'SYSTEM':
+	    self._logger.info("Using System Commands for On/Off")
         elif self.switchingMethod == 'GPIO':
             self._logger.info("Using GPIO for On/Off")
             self._logger.info("Configuring GPIO for pin %s" % self.onoffGPIOPin)
@@ -233,14 +235,14 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                 self._logger.debug("Switching PSU On Using COMMAND: %s" % self.onCommand)
                 self._printer.commands(self.onCommand)
             elif self.switchingMethod == 'SYSTEM':
-                 self._logger.debug("Switching PSU On Using SYSTEM: %s" % self.onCommand)
-                 os.system(self.onCommand)
-              elif self.switchingMethod == 'GPIO':
-                   self._logger.debug("Switching PSU On Using GPIO: %s" % self.onoffGPIOPin)
-                   if not self.invertonoffGPIOPin:
-                       pin_output=GPIO.HIGH
-                   else:
-                       pin_output=GPIO.LOW
+                self._logger.debug("Switching PSU On Using SYSTEM: %s" % self.onCommand)
+                os.system(self.onCommand)
+            elif self.switchingMethod == 'GPIO':
+                self._logger.debug("Switching PSU On Using GPIO: %s" % self.onoffGPIOPin)
+                if not self.invertonoffGPIOPin:
+                    pin_output=GPIO.HIGH
+                else:
+                    pin_output=GPIO.LOW
 
                 try:
                     GPIO.output(self.onoffGPIOPin, pin_output)
@@ -262,17 +264,17 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             elif self.switchingMethod == 'SYSTEM':
                 self._logger.debug("Switching PSU Off Using SYSTEM: %s" % self.offCommand)
                 os.system(self.offCommand)
-              elif self.switchingMethod == 'GPIO':
-                    self._logger.debug("Switching PSU Off Using GPIO: %s" % self.onoffGPIOPin)
-                    if not self.invertonoffGPIOPin:
-                        pin_output=GPIO.LOW
-                    else:
-                        pin_output=GPIO.HIGH
-
-                    try:
-                        GPIO.output(self.onoffGPIOPin, pin_output)
-                    except (RuntimeError, ValueError) as e:
-                        self._logger.error(e)
+            elif self.switchingMethod == 'GPIO':
+                self._logger.debug("Switching PSU Off Using GPIO: %s" % self.onoffGPIOPin)
+                if not self.invertonoffGPIOPin:
+                    pin_output=GPIO.LOW
+                else:
+                    pin_output=GPIO.HIGH
+		
+                try:
+                    GPIO.output(self.onoffGPIOPin, pin_output)
+                except (RuntimeError, ValueError) as e:
+                    self._logger.error(e)
 
             if not self.enableSensing:
                 self._noSensing_isPSUOn = False

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -28,8 +28,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
 	self.onSysCommand = ''
 	self.offSysCommand = ''
         self.autoOn = False
-        self.autoonGCodeCommands = ''
-        self.autoonGCodeCommandsArray = []
+        self.autoOnCommands = ''
+        self.autoOnCommandsArray = []
         self.powerOffWhenIdle = False
         self.idleTimeout = 0
         self.idleIgnoreCommands = ''
@@ -75,9 +75,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.autoOn = self._settings.get_boolean(["autoOn"])
         self._logger.debug("autoOn: %s" % self.autoOn)
 
-        self.autoonGCodeCommands = self._settings.get(["autoonGCodeCommands"])
-        self.autoonGCodeCommandsArray = self.autoonGCodeCommands.split(',')
-        self._logger.debug("autoonGCodeCommands: %s" % self.autoonGCodeCommands)
+        self.autoOnCommands = self._settings.get(["autoOnCommands"])
+        self.autoOnCommandsArray = self.autoOnCommands.split(',')
+        self._logger.debug("autoOnCommands: %s" % self.autoOnCommands)
 
         self.powerOffWhenIdle = self._settings.get_boolean(["powerOffWhenIdle"])
         self._logger.debug("powerOffWhenIdle: %s" % self.powerOffWhenIdle)
@@ -227,7 +227,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
 
     def hook_gcode_queuing(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
         if gcode:
-            if (not self.isPSUOn and self.autoOn and (gcode in self.autoonGCodeCommandsArray)):
+            if (not self.isPSUOn and self.autoOn and (gcode in self.autoOnCommandsArray)):
                 self._logger.info("Auto-On - Turning PSU On (Triggered by %s)" % gcode)
                 self.turn_psu_on()
 
@@ -317,7 +317,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             enableSensing = False,
             senseGPIOPin = 0,
             autoOn = False,
-            autoonGCodeCommands = "G0,G1,G2,G3,G10,G11,G28,G29,G32,M104,M109,M140,M190",
+            autoOnCommands = "G0,G1,G2,G3,G10,G11,G28,G29,G32,M104,M109,M140,M190",
             powerOffWhenIdle = False,
             idleTimeout = 30,
             idleIgnoreCommands = 'M105',
@@ -342,8 +342,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.enableSensing = self._settings.get_boolean(["enableSensing"])
         self.senseGPIOPin = self._settings.get_int(["senseGPIOPin"])
         self.autoOn = self._settings.get_boolean(["autoOn"])
-        self.autoonGCodeCommands = self._settings.get(["autoonGCodeCommands"])
-        self.autoonGCodeCommandsArray = self.autoonGCodeCommands.split(',')
+        self.autoOnCommands = self._settings.get(["autoOnCommands"])
+        self.autoOnCommandsArray = self.autoOnCommands.split(',')
         self.powerOffWhenIdle = self._settings.get_boolean(["powerOffWhenIdle"])
         self.idleTimeout = self._settings.get_int(["idleTimeout"])
         self.idleIgnoreCommands = self._settings.get(["idleIgnoreCommands"])

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -129,7 +129,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                 self._logger.error(e)
 
     def check_psu_state(self):
-	    old_isPSUOn = self.isPSUOn
+	old_isPSUOn = self.isPSUOn
 
         if self.enableSensing:
             self._logger.debug("Polling PSU state...")

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -118,8 +118,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         
         if self.switchingMethod == 'COMMAND':
             self._logger.info("Using Commands for On/Off")
-	    elif self.switchingMethod == 'SYSTEM':
-	        self._logger.info("Using System Commands for On/Off")
+	elif self.switchingMethod == 'SYSTEM':
+	    self._logger.info("Using System Commands for On/Off")
         elif self.switchingMethod == 'GPIO':
             self._logger.info("Using GPIO for On/Off")
             self._logger.info("Configuring GPIO for pin %s" % self.onoffGPIOPin)

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -25,8 +25,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.invertonoffGPIOPin = False
         self.onGCodeCommand = ''
         self.offGCodeCommand = ''
-	    self.onSysCommand = ''
-	    self.offSysCommand = ''
+	self.onSysCommand = ''
+	self.offSysCommand = ''
         self.autoOn = False
         self.autoonGCodeCommands = ''
         self.autoonGCodeCommandsArray = []

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -25,8 +25,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self.invertonoffGPIOPin = False
         self.onGCodeCommand = ''
         self.offGCodeCommand = ''
-	    self.onSysCommand = ''
-	    self.offSysCommand = ''
+	self.onSysCommand = ''
+	self.offSysCommand = ''
         self.autoOn = False
         self.autoOnCommands = ''
         self.autoOnCommandsArray = []
@@ -122,8 +122,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         
         if self.switchingMethod == 'COMMAND':
             self._logger.info("Using Commands for On/Off")
-	    elif self.switchingMethod == 'SYSTEM':
-	        self._logger.info("Using System Commands for On/Off")
+	elif self.switchingMethod == 'SYSTEM':
+	    self._logger.info("Using System Commands for On/Off")
         elif self.switchingMethod == 'GPIO':
             self._logger.info("Using GPIO for On/Off")
             self._logger.info("Configuring GPIO for pin %s" % self.onoffGPIOPin)

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -24,28 +24,27 @@
     <div class="control-group">
         <label class="control-label">PSU On GCODE Command</label>
         <div class="controls">
-            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.onCommand">
+            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.onGCodeCommand">
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">PSU Off GCODE Command</label>
         <div class="controls">
-            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.offCommand">
+            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.offGCodeCommand">
         </div>
     </div>
         <!-- /ko -->
-    <!-- /ko -->
         <!-- ko if: settings.plugins.psucontrol.switchingMethod() === "SYSTEM" -->
     <div class="control-group">
         <label class="control-label">PSU On System Command</label>
         <div class="controls">
-            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.onCommand">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.onSysCommand">
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">PSU Off System Command</label>
         <div class="controls">
-            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.offCommand">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.offSysCommand">
         </div>
     </div>
         <!-- /ko -->

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -57,6 +57,11 @@
             <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.enableSensing"> Get PSU on/off state via GPIO (Recommended)
             </label>
         </div>
+        <div class="controls">
+            <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.assumeOnIfConnected"> Assume Printer is On if Octoprint is Connected
+            </label>
+        </div>
     </div>
     <!-- ko if: settings.plugins.psucontrol.enableSensing() -->
     <div class="control-group">

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -6,8 +6,9 @@
         <div class="controls">
             <select data-bind="value: settings.plugins.psucontrol.switchingMethod">
                 <option value="">Select Method...</option>
-                <option value="COMMAND">Command</option>
-                <option value="GPIO">GPIO</option>
+                <option value="COMMAND">GCODE Command</option>
+                <option value="GPIO">GPIO Pin</option>
+                <option value="SYSTEM">System Command</option>
             </select>
         </div>
     </div>
@@ -21,13 +22,28 @@
     <!-- /ko -->
         <!-- ko if: settings.plugins.psucontrol.switchingMethod() === "COMMAND" -->
     <div class="control-group">
-        <label class="control-label">PSU On Command</label>
+        <label class="control-label">PSU On GCODE Command</label>
         <div class="controls">
             <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.onCommand">
         </div>
     </div>
     <div class="control-group">
-        <label class="control-label">PSU Off Command</label>
+        <label class="control-label">PSU Off GCODE Command</label>
+        <div class="controls">
+            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.offCommand">
+        </div>
+    </div>
+        <!-- /ko -->
+    <!-- /ko -->
+        <!-- ko if: settings.plugins.psucontrol.switchingMethod() === "SYSTEM" -->
+    <div class="control-group">
+        <label class="control-label">PSU On System Command</label>
+        <div class="controls">
+            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.onCommand">
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">PSU Off System Command</label>
         <div class="controls">
             <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.offCommand">
         </div>

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -39,13 +39,13 @@
     <div class="control-group">
         <label class="control-label">PSU On System Command</label>
         <div class="controls">
-            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.onCommand">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.onCommand">
         </div>
     </div>
     <div class="control-group">
         <label class="control-label">PSU Off System Command</label>
         <div class="controls">
-            <input type="text" class="input-mini" data-bind="value: settings.plugins.psucontrol.offCommand">
+            <input type="text" class="input-block-level" data-bind="value: settings.plugins.psucontrol.offCommand">
         </div>
     </div>
         <!-- /ko -->


### PR DESCRIPTION
This adaptation enables the usage of system (*nix) commands in place of GCODE / GPIO to control your PSU.

My specific use case relies on interaction with a cheap Internet connected Power outlet (https://www.insigniaproducts.com/pdp/NS-SP1X7/5529012).  I have built shellscripts (by reverse engineering Insignia's implementation) to facilitate power on and power off operations.

I did some reasonable testing last night and all looks good.  Since I don't have anything GPIO and/or GCODE based I was unable to validate those implementation, but I'm pretty sure they remained unchanged.