### PR TITLE
Fix check_psu_state method when self.invertonoffGPIOPin is True

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -209,9 +209,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             self._logger.debug("Result: %s" % r)
 
             if r==1:
-                self.isPSUOn = True
+                self.isPSUOn = not self.invertonoffGPIOPin
             elif r==0:
-                self.isPSUOn = False
+                self.isPSUOn = self.invertonoffGPIOPin
         else:
             self.isPSUOn = self._noSensing_isPSUOn
         


### PR DESCRIPTION
When using GPIO mode and "Inverted" checkbox is checked, check_psu_state doesn't returns the correct state.