### PR TITLE
Made the RPi.GPIO requirement optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 OctoPrint
-RPi.GPIO>=0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 OctoPrint
+RPi.GPIO>=0.6.3


### PR DESCRIPTION
I made the RPi.GPIO requirement optional so that it can be used on other systems with System Commands. 
Maybe you can make a change to the settings so that the GPIO option is not even available when the RPi.GPIO is not available.