### PR TITLE
Removed GPiO RPi requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 OctoPrint
-RPi.GPIO>=0.6.3

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 plugin_identifier = "psucontrol"
 plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-PSUControl"
-plugin_version = "0.1.7"
+plugin_version = "0.1.8"
 plugin_description = "Control ATX/AUX power supply."
 plugin_author = "Shawn Bruce"
 plugin_author_email = "kantlivelong@gmail.com"


### PR DESCRIPTION
Removal of the GPiO library is necessary for usage on non-Pi installations such as Windows.
Removing the requirement line allows the install to finish with no issues arising when using the plug-in.

A better workaround would be to identify the host OS before checking requirements.