### PR TITLE
Support getting the PSU state with a GET request

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -590,6 +590,9 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             getPSUState=[]
         )
 
+    def on_api_get(self, request):
+        return self.on_api_command("getPSUState", [])
+
     def on_api_command(self, command, data):
         if not user_permission.can():
             return make_response("Insufficient rights", 403)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
According to [common practices](https://restfulapi.net/http-methods/#get) GET is used `to retrieve resource representation/information only`. This PR enables the plugin to respond to get requests to its API-endpoint with the current PSU state.

#### How was it tested? How can it be tested by the reviewer?
I hot-patched the installed plugin on my octoprint instance with the newly added function. Afterwards I used curl to fetch the new endpoint:

```
$ curl -s -H "X-Api-Key: <my-api-key>" http://octoprint.example.com/api/plugin/psucontrol
{            
  "isPSUOn": false
}
$ curl -s -H "Content-Type: application/json" -H "X-Api-Key: <my-api-key> -X POST -d '{ "command":"turnPSUOn" }' http://octoprint.example.com/api/plugin/psucontrol
$ curl -s -H "X-Api-Key: <my-api-key>" http://octoprint.example.com/api/plugin/psucontrol
{            
  "isPSUOn": true
}
```

For reviewers I suggest to do the same or alternatively point pip to install from my branch.

#### Any background context you want to provide?
My main motivation was to get the PSU control available in my home-assistant instance. For this I wanted to use the [RESTful Switch component](https://www.home-assistant.io/integrations/switch.rest/). This component is implemented as such that it retrieves the status over GET and sends updates over POST (following the best-practices linked above). To quote: "The switch can get the state via GET and set the state via POST on a given REST resource."

#### Further notes
I implemented this feature by calling the original implementation of this. This allows backwards compatibility and makes sure the same access restrictions are in place. Technically speaking I think that the "getPSUState"-POST-request should be removed but this is not a decision I wanted to take (especially since it might break existing setups).
