### PR TITLE
Python 3 compat

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -766,6 +766,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         )
 
 __plugin_name__ = "PSU Control"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
     global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import setuptools
 plugin_identifier = "psucontrol"
 plugin_package = "octoprint_%s" % plugin_identifier
 plugin_name = "OctoPrint-PSUControl"
-plugin_version = "0.1.8"
+plugin_version = "0.1.9"
 plugin_description = "Control ATX/AUX power supply."
 plugin_author = "Shawn Bruce"
 plugin_author_email = "kantlivelong@gmail.com"


### PR DESCRIPTION
Adding python 3 compatibility tag, as it wouldn't install on octoprint 1.4.0 rc on python 3 (python 2 is EOL)