### PR TITLE
WIP: updating RPI.GPIO version requirement to fix aarch64 detection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 OctoPrint
-RPi.GPIO>=0.6.3
+RPi.GPIO>=0.7.0


### PR DESCRIPTION
Requiring the 0.7.0 or above will hopefully fix some issues we're
having using PSUControl on Raspberry Pi 4.

see:
- RPI.GPIO changelog for 0.7.0 at https://pypi.org/project/RPi.GPIO/
- https://sourceforge.net/p/raspberry-gpio-python/tickets/161/
- https://sourceforge.net/p/raspberry-gpio-python/tickets/165/
