### PR TITLE
Automatically connect printer after PSU on

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -553,12 +553,12 @@ class PSUControl(octoprint.plugin.StartupPlugin,
 
 
     def after_psu_on_delay(self):
+            if self.postOnConnect:
+                self._printer.connect()
+
             if self.afterOnGCodeCommands:
                 for command in self._afterOnGCodeCommandsArray:
                     self._printer.commands(command)
-
-            if self.postOnConnect:
-                self._printer.connect()
 
             self.check_psu_state()
 

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -171,6 +171,11 @@
                 <span class="add-on">sec</span>
             </div>
         </div>
+        <div class="controls">
+            <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.postOnConnect"> Automatically connect to printer after delay
+            </label>
+        </div>
     </div>  
     <br />
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
After powering on the printer it would be great if the connection is opened automatically. This is basically what this pull request implements.

It adds a new configuration option to enable powerOnConnect - defaults to False as this is the same behavior as before.

Additionally there are two minor changes implemented, kinda related to the main one:

* Removed blocking `time.sleep` from `turn_psu_on()` by using a background thread.
* Disconnect from printer before powering off instead of after in `turn_psu_off()`.

#### How was it tested? How can it be tested by the reviewer?
Enable the new option powerOnConnect, restart OctoPrint (to make sure setting is saved) and turn PSU on - it did automatically connect to the printer.
Disable the new option powerOnConnect, restart OctoPrint and turn PCU on - it did NOT connect to the printer.
