### PR TITLE
Add helpers and event to plugin

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,22 +1,30 @@
 <!--
 READ THE FOLLOWING FIRST:
 
-If not already done, please read the Wiki: https://github.com/kantlivelong/OctoPrint-PSUControl/wiki
+If not already done, please read the Wiki: 
+https://github.com/kantlivelong/OctoPrint-PSUControl/wiki
 
-This is a bug and feature tracker, please only use it to report bugs
-or request features within OctoPrint-PSUControl.
+This is a bug tracker, please only use it to report bugs
+within OctoPrint-PSUControl.
 
 Do not seek support here ("I need help with ...", "I have a
 question ..."), that belongs on the community forum at 
-discourse.octoprint.org, NOT here.
+https://community.octoprint.org
+All support related questions will be closed.
 
-Mark requests with a "[Request]" prefix in the title please. For bug
-reports fully fill out the bug reporting template.
+Feature requests should be made at:
+https://feathub.com/kantlivelong/OctoPrint-PSUControl
 
 When reporting a bug do NOT delete ANY lines from the template.
 
 Make sure any bug you want to report is still present with the CURRENT
 OctoPrint-PSUControl version.
+
+To summarize:
+Wiki:             https://github.com/kantlivelong/OctoPrint-PSUControl/wiki
+Support:          https://community.octoprint.org
+Feature Requests: https://feathub.com/kantlivelong/OctoPrint-PSUControl
+Bug Reports:      Here
 
 Thanks!
 -->

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ Supports Commands (G-Code or System) or GPIO to switch power supply on/off.
  
  
 ## Setup
-
 Install the plugin using Plugin Manager from Settings
- 
  
 ## Settings
 See the [Wiki](https://github.com/kantlivelong/OctoPrint-PSUControl/wiki/Settings)
@@ -21,3 +19,9 @@ See the [Wiki](https://github.com/kantlivelong/OctoPrint-PSUControl/wiki/Trouble
 
 ## API
 See the [Wiki](https://github.com/kantlivelong/OctoPrint-PSUControl/wiki/API)
+
+## Support
+Help can be found at the [OctoPrint Community Forums](https://community.octoprint.org)
+
+## Feature Requests
+[![Feature Requests](https://feathub.com/kantlivelong/OctoPrint-PSUControl?format=svg)](https://feathub.com/kantlivelong/OctoPrint-PSUControl)

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -582,6 +582,10 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             time.sleep(0.1)
             self.check_psu_state()
 
+    def get_psu_state(self):
+        isPSUOn=self.isPSUOn
+        return isPSUOn
+
     def get_api_commands(self):
         return dict(
             turnPSUOn=[],
@@ -768,12 +772,25 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             )
         )
 
+    def _register_custom_events(*args, **kwargs):
+        return ["psu_state_changed"]
+
 __plugin_name__ = "PSU Control"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
+
+    plugin = PSUControl()
+
     global __plugin_implementation__
-    __plugin_implementation__ = PSUControl()
+    __plugin_implementation__ = plugin
+
+    global __plugin_helpers__
+    __plugin_helpers__ = dict(
+        get_psu_state=plugin.get_psu_state,
+        turn_psu_on=plugin.turn_psu_on,
+        turn_psu_off=plugin.turn_psu_off
+    )
 
     global __plugin_hooks__
     __plugin_hooks__ = {

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -7,6 +7,7 @@ __copyright__ = "Copyright (C) 2017 Shawn Bruce - Released under terms of the AG
 
 import octoprint.plugin
 from octoprint.server import user_permission
+from octoprint.events import Events
 import time
 import subprocess
 import threading
@@ -369,6 +370,11 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                 return
             
             self._logger.debug("isPSUOn: %s" % self.isPSUOn)
+
+            if (old_isPSUOn != new_isPSUOn):
+                self._logger.debug("PSU state changed, firing psu_state_changed event.")
+                event = Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
+                self._event_bus.fire(event, payload=new_isPSUOn)
 
             if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:
                 self._start_idle_timer()
@@ -795,5 +801,6 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.comm.protocol.gcode.queuing": __plugin_implementation__.hook_gcode_queuing,
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.events.register_custom_events": __plugin_implementation__._register_custom_events
     }

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -371,10 +371,10 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             
             self._logger.debug("isPSUOn: %s" % self.isPSUOn)
 
-            if (old_isPSUOn != new_isPSUOn):
+            if (old_isPSUOn != self.isPSUOn):
                 self._logger.debug("PSU state changed, firing psu_state_changed event.")
                 event = Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
-                self._event_bus.fire(event, payload=dict(psu_state=new_isPSUOn))
+                self._event_bus.fire(event, payload=dict(psu_state=self.isPSUOn))
 
             if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:
                 self._start_idle_timer()
@@ -589,8 +589,11 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             self.check_psu_state()
 
     def get_psu_state(self):
-        isPSUOn=self.isPSUOn
-        return isPSUOn
+        return self.isPSUOn
+        # if self.isPSUOn:
+        #     return True
+        # else:
+        #     return False
 
     def get_api_commands(self):
         return dict(
@@ -785,17 +788,14 @@ __plugin_name__ = "PSU Control"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
-
-    plugin = PSUControl()
-
     global __plugin_implementation__
-    __plugin_implementation__ = plugin
+    __plugin_implementation__ = PSUControl()
 
     global __plugin_helpers__
     __plugin_helpers__ = dict(
-        get_psu_state=plugin.get_psu_state,
-        turn_psu_on=plugin.turn_psu_on,
-        turn_psu_off=plugin.turn_psu_off
+        get_psu_state = __plugin_implementation__.get_psu_state,
+        turn_psu_on = __plugin_implementation__.turn_psu_on,
+        turn_psu_off = __plugin_implementation__.turn_psu_off
     )
 
     global __plugin_hooks__

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -374,7 +374,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             if (old_isPSUOn != new_isPSUOn):
                 self._logger.debug("PSU state changed, firing psu_state_changed event.")
                 event = Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
-                self._event_bus.fire(event, payload=new_isPSUOn)
+                self._event_bus.fire(event, payload=dict(psu_state=new_isPSUOn))
 
             if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:
                 self._start_idle_timer()


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint-PSUControl, it's highly appreciated!

Before submitting please make sure you have ticked all points on this checklist:

  * [x] Your PR targets the devel branch.
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style.
  * [x] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?
The first commit exposes the turn_psu_on and turn_psu_off as helpers to other plugins. Furthermore, it adds a third function, get_psu_state, as a helper. This is necessary to enable other plugins to do PSU things.
The second and third commit in this PR make the plugin fire an event when the PSU state has changed, so plugins can interact when the PSU is turned on or off.

#### How was it tested? How can it be tested by the reviewer?
This was tested both in a docker test setup with only this plugin and MQTT/HomeAssistant installed, as well as my own 'live' Raspberry Pi + Creality printer setup.
Since there isn't really any way to test this without a plugin that implements these and there isn't any other than my version of the OctoPrint-HomeAssistant plugin, it would be necessary to create a testing plugin for this. I'll look into creating such a plugin.

#### Any background context you want to provide?
I did some modification to the OctoPrint-HomeAssistant plugin, which publishes OctoPrint into my home automation system. I was wondering if I could get it to publish a PSU switch when PSUControl is installed on the OctoPrint system. The helper functions will enable the OctoPrint-HomeAssistant plugin to toggle the PSU when a switch is toggled in the home automation, the event will trigger the plugin to update the home automation when the PSU is toggled from within OctoPrint.