### PR TITLE
Potential fix for #162, don't set scripts to be undefined

### DIFF
--- a/octoprint_psucontrol/static/js/psucontrol.js
+++ b/octoprint_psucontrol/static/js/psucontrol.js
@@ -16,6 +16,8 @@ $(function() {
 
         self.onBeforeBinding = function() {
             self.settings = self.settingsViewModel.settings;
+            self.scripts_gcode_psucontrol_post_on(self.settings.scripts.gcode["psucontrol_post_on"]());
+            self.scripts_gcode_psucontrol_pre_off(self.settings.scripts.gcode["psucontrol_pre_off"]());
         };
 
         self.onSettingsShown = function () {

--- a/octoprint_psucontrol/static/js/psucontrol.js
+++ b/octoprint_psucontrol/static/js/psucontrol.js
@@ -6,8 +6,8 @@ $(function() {
         self.loginState = parameters[1];
         
         self.settings = undefined;
-        self.scripts_gcode_psucontrol_post_on = ko.observable(undefined);
-        self.scripts_gcode_psucontrol_pre_off = ko.observable(undefined);
+        self.scripts_gcode_psucontrol_post_on = ko.observable("");
+        self.scripts_gcode_psucontrol_pre_off = ko.observable("");
 
         self.hasGPIO = ko.observable(true);
         self.isPSUOn = ko.observable(undefined);


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Attempts to fix https://github.com/kantlivelong/OctoPrint-PSUControl/issues/162, and in return https://github.com/QuinnDamerell/OctoPrint-OctoEverywhere/issues/12 and probably https://github.com/cp2004/OctoPrint-EEPROM-Marlin/issues/14 and https://github.com/cp2004/OctoPrint-EEPROM-Marlin/issues/13, https://github.com/OctoPrint/OctoPrint/issues/3827#issuecomment-735462892 and probably more. Yeah...

When scripts were set as undefined, OctoPrint's backend settings API couldn't handle it, and crashed. This caused a bit of a problem with setup wizards.

There was even a workaround in core OctoPrint - https://github.com/OctoPrint/OctoPrint/commit/ba27cdfd9aff8884daca52a61ced30b56ca9a644 - to stop this from happening again.

#### How was it tested? How can it be tested by the reviewer?
Confession: It wasn't. Can be tested by installing PSU control, then having a wizard plugin installed after. Wizard can't be dismissed due to internal error on settings API.


