### PR TITLE
Add option to automatically turn PSU on before starting a print

### DIFF
--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -145,7 +145,10 @@
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">
-            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.autoOn"> Automatically turn PSU ON
+            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.autoOnBeforePrint"> Automatically turn PSU on before a print is started
+            </label>
+            <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.autoOn"> Automatically turn PSU on when GCODE recieved
             </label>
         </div>
     </div>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Related to the same issues I was trying to solve in #166, instead of looking for gcode, hooking the beforePrintStarted script allows PSU control to turn on the PSU before starting a print job.

#### How was it tested? How can it be tested by the reviewer?

With this patch installed, keep the Automatically turn PSU on before print is started option disabled. Notice the PSU does not automatically turn on when you start a print. Turn the option on, now it does.
