### PR TITLE
Add idle countdown timer to navbar.

### DIFF
--- a/octoprint_psucontrol/static/js/psucontrol.js
+++ b/octoprint_psucontrol/static/js/psucontrol.js
@@ -14,6 +14,7 @@ $(function() {
         self.scripts_gcode_psucontrol_pre_off = ko.observable(undefined);
 
         self.isPSUOn = ko.observable(undefined);
+        self.idleTimeLeft = ko.observable(undefined);
 
         self.psu_indicator = $("#psucontrol_indicator");
 
@@ -101,6 +102,10 @@ $(function() {
 
             if (data.isPSUOn !== undefined) {
                 self.isPSUOn(data.isPSUOn);
+            }
+
+            if (data.idleTimeLeft !== undefined) {
+                self.idleTimeLeft(data.idleTimeLeft);
             }
         };
 

--- a/octoprint_psucontrol/templates/psucontrol_navbar.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_navbar.jinja2
@@ -1,3 +1,4 @@
 <a id="psucontrol_indicator" class="pull-right" title="Toggle PSU" href="#" data-bind="click: function() { loginState.isUser() && $root.togglePSU(); }, visible: (isPSUOn() !== undefined)" style="display: none">
     <i class="icon-bolt"></i>
+    <span data-bind="attr: { title: 'Idle Countdown' }, html: idleTimeLeft()"></span>
 </a>

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -5,6 +5,9 @@
             <label class="checkbox">
             <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.enablePowerOffWarningDialog"> Show warning dialog when powering off via toggle button.
             </label>
+            <label class="checkbox">
+            <input type="checkbox" data-bind="checked: settings.plugins.psucontrol.enableIdleCountdownTimer"> Show idle countdown timer in the navbar.
+            </label>
         </div>
     </div>
     <!-- ko if: settings.plugins.psucontrol.switchingMethod() === "GPIO" || settings.plugins.psucontrol.sensingMethod() === "GPIO" -->


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Added a countdown timer to the navbar that shows when the PSU will be turned off, if "Automatically turn PSU OFF when idle" is enabled in settings.  A setting was also added to enable / disable display of the timer in the navbar.

The countdown is NOT displayed in the navbar when the following is TRUE:
 - PSU is OFF
 - Print is ongoing
 - Print is paused
 - "Automatically turn PSU OFF when idle" is UNCHECKED in Settings.
 - "Show idle countdown timer in the navbar" is UNCHECKED in Settings.

#### How was it tested? How can it be tested by the reviewer?
Tested on my OctoPrint instance running on an RPi3 B+ 

#### Screenshots (if appropriate)
Idle countdown timer in navbar:
![idle_countdown_timer](https://user-images.githubusercontent.com/21278439/109431315-ef03dc00-79d3-11eb-9ae0-c1efecd33b83.png)

Settings toggle:
![idle_countdown_timer_settings](https://user-images.githubusercontent.com/21278439/109431904-c7fad980-79d6-11eb-823f-9f527b5e581e.png)


