### PR TITLE
Helpers and event added

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -383,6 +383,11 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             
             self._logger.debug("isPSUOn: %s" % self.isPSUOn)
 
+            if (old_isPSUOn != self.isPSUOn):
+                self._logger.debug("PSU state changed, firing psu_state_changed event.")
+                event = Events.PLUGIN_PSUCONTROL_PSU_STATE_CHANGED
+                self._event_bus.fire(event, payload=dict(psu_state=self.isPSUOn))
+
             if (old_isPSUOn != self.isPSUOn) and self.isPSUOn:
                 self._start_idle_timer()
             elif (old_isPSUOn != self.isPSUOn) and not self.isPSUOn:
@@ -807,6 +812,12 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             )
         )
 
+    def get_psu_state(self):
+        return self.isPSUOn
+
+    def register_custom_events(self):
+        return ["psu_state_changed"]
+
 __plugin_name__ = "PSU Control"
 __plugin_pythoncompat__ = ">=2.7,<4"
 
@@ -817,5 +828,13 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.comm.protocol.gcode.queuing": __plugin_implementation__.hook_gcode_queuing,
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
+        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+        "octoprint.events.register_custom_events": __plugin_implementation__.register_custom_events
     }
+
+    global __plugin_helpers__
+    __plugin_helpers__ = dict(
+        get_psu_state = __plugin_implementation__.get_psu_state,
+        turn_psu_on = __plugin_implementation__.turn_psu_on,
+        turn_psu_off = __plugin_implementation__.turn_psu_off
+    )


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint-PSUControl, it's highly appreciated!

Before submitting please make sure you have ticked all points on this checklist:

  * [x] Your PR targets the devel branch.
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style.
  * [x] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?
This adds an event to which other plugins can subscribe so they can react to turning the PSU on and off. It also adds helpers, which is nothing more than allowing other plugins to execute turn_psu_on and turn_psu_off. I also added a get_psu_state which is exposed as a helper so other plugins can retrieve the current state of the PSU.

#### How was it tested? How can it be tested by the reviewer?
This was tested with my modified version of the OctoPrint-HomeAssistant plugin, which I will release as soon as it's possible to use it together with PSU Control.
To test this, you'd need a working Home Assistant installation with MQTT configured. (I can help providing that)

#### Any background context you want to provide?
This should not have any impact on the existing functionality of the plugin.

#### What are the relevant tickets if any?
#174

#### Screenshots (if appropriate)

#### Further notes
If this can be merged, I will look into backporting the PLUGIN switch method you mentioned in the ticket.