### PR TITLE
Add OctoPrint connection-based sensing

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -278,6 +278,14 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                         )
 
                 self.isPSUOn = r
+            elif self.config['sensingMethod'] == 'CONNECTION':
+                new_isPSUOn = False
+                if self._printer.is_closed_or_error():
+                    new_isPSUOn = False
+                else:
+                    new_isPSUOn = True
+
+                self.isPSUOn = new_isPSUOn
             else:
                 self.isPSUOn = False
 
@@ -481,7 +489,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                         )
                         return
 
-            if self.config['sensingMethod'] not in ('GPIO', 'SYSTEM', 'PLUGIN'):
+            if self.config['sensingMethod'] not in ('GPIO', 'SYSTEM', 'PLUGIN', 'CONNECTION'):
                 self._noSensing_isPSUOn = True
 
             time.sleep(0.1 + self.config['postOnDelay'])
@@ -550,7 +558,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             if self.config['disconnectOnPowerOff']:
                 self._printer.disconnect()
 
-            if self.config['sensingMethod'] not in ('GPIO', 'SYSTEM', 'PLUGIN'):
+            if self.config['sensingMethod'] not in ('GPIO', 'SYSTEM', 'PLUGIN', 'CONNECTION'):
                 self._noSensing_isPSUOn = False
 
             time.sleep(0.1)

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -117,6 +117,7 @@
                 <option value="SYSTEM">System Command</option>
                 <option value="GPIO">GPIO</option>
                 <option value="PLUGIN">Plugin</option>
+                <option value="CONNECTION">OctoPrint Connection</option>
             </select>
         </div>
     </div>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds a new sensing option that uses the OctoPrint connection status to determine whether the power is on or off. If OctoPrint is disconnected or in an error connection state, the power is assumed to be off. Otherwise it is assumed to be powered on.

#### How was it tested? How can it be tested by the reviewer?
1. Select "OctoPrint Connection" from the Sensing drop-down  
1. Power on the printer and connect OctoPrint  
1. Observe the power status  
1. Power off the printer or disconnect OctoPrint  
1. Observe the power status

#### Any background context you want to provide?
This option was originally intended to be used with a smart plug that can be controlled via an IFTTT curl system command, but can't easily be sensed because IFTTT doesn't offer that capability. The internal sense option works okay so long as you only turn the printer on from the PSU control plugin, but if you ever manually turn the printer on by hand or via Alexa, the PSU plugin wouldn't know. When paired with the PortLister plugin, which automatically connects to the powered on printer, this change allows you to rely on the assumption that if OctoPrint is connected, then the printer must be on, and if OctoPrint isn't connected then the printer must be off. 