### PR TITLE
Make the print actually start after uploading a file from API

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -574,6 +574,8 @@ class PSUControl(octoprint.plugin.StartupPlugin,
              flask.request.method == 'POST' and
              flask.request.values.get('print', 'false') in valid_boolean_trues):
                 self.on_api_command("turnPSUOn", [])
+                time.sleep(self.config['postOnDelay'])
+                self._printer.start_print()
 
 
     def on_event(self, event, payload):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

"Add support for turning the printer on prior to printing when uploading file from API" only starts the psu but not the print.

To make it work as expected it is necessary to make sure the printer is connected and then retrigger a print command. This is because the "original" print command gets lost if the printer is not 100% ready when the api file upload comes in. 

#### How was it tested? How can it be tested by the reviewer?

Tested it like this:

1) PSU is off
2) send file with print command from prusa slicer

--> printer turns on, connects, starts selected file --> works

#### Any background context you want to provide?

This is probably the most basic way to do this fix, maybe there is a better way. 

