### PR TITLE
Allow same GPIO for switching and sensing

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -64,7 +64,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self._idleTimer = None
         self._waitForHeaters = False
         self._skipIdleTimer = False
-        self._configuredGPIOPins = {}
+        self._configuredGPIOPins: Dict[str, periphery.CdevGPIO] = {}
         self._noSensing_isPSUOn = False
         self.isPSUOn = False
 
@@ -166,6 +166,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         for k, pin in self._configuredGPIOPins.items():
             self._logger.debug("Cleaning up {} pin {}".format(k, pin.name))
             try:
+                # should work, even if we try to clean up the same GPIO twice
                 pin.close()
             except Exception:
                 self._logger.exception(
@@ -181,44 +182,49 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             self._logger.info("Using GPIO for On/Off")
             self._logger.info("Configuring GPIO for pin {}".format(self.config['onoffGPIOPin']))
 
-            if not self.config['invertonoffGPIOPin']:
-                initial_output = 'low'
-            else:
-                initial_output = 'high'
-
             try:
-                pin = periphery.GPIO(self.config['GPIODevice'], self.config['onoffGPIOPin'], initial_output)
-                self._configuredGPIOPins['switch'] = pin
+                pin = periphery.CdevGPIO(
+                    path=self.config['GPIODevice'],
+                    line=self.config['onoffGPIOPin'],
+                    direction="out",
+                    inverted=self.config['invertonoffGPIOPin']
+                )
             except Exception:
                 self._logger.exception(
                     "Exception while setting up GPIO pin {}".format(self.config['onoffGPIOPin'])
                 )
+            else:
+                self._configuredGPIOPins['switch'] = pin
 
         if self.config['sensingMethod'] == 'GPIO':
             self._logger.info("Using GPIO sensing to determine PSU on/off state.")
-            self._logger.info("Configuring GPIO for pin {}".format(self.config['senseGPIOPin']))
 
 
-            if not SUPPORTS_LINE_BIAS:
-                if self.config['senseGPIOPinPUD'] != '':
-                    self._logger.warning("Kernel version 5.5 or greater required for GPIO bias. Using 'default'.")
-                bias = "default"
-            elif self.config['senseGPIOPinPUD'] == '':
-                bias = "disable"
-            elif self.config['senseGPIOPinPUD'] == 'PULL_UP':
-                bias = "pull_up"
-            elif self.config['senseGPIOPinPUD'] == 'PULL_DOWN':
-                bias = "pull_down"
-            else:
-                bias = "default"
-
-            try:
-                pin = periphery.CdevGPIO(path=self.config['GPIODevice'], line=self.config['senseGPIOPin'], direction='in', bias=bias)
+            if self.config['switchingMethod'] == 'GPIO' and self.config['senseGPIOPin'] == self.config['onoffGPIOPin']:
+                self._logger.info("Sensing through same pin as switching.")
                 self._configuredGPIOPins['sense'] = pin
-            except Exception:
-                self._logger.exception(
-                    "Exception while setting up GPIO pin {}".format(self.config['senseGPIOPin'])
-                )
+            else:
+                self._logger.info("Configuring GPIO for pin {}".format(self.config['senseGPIOPin']))
+                if not SUPPORTS_LINE_BIAS:
+                    if self.config['senseGPIOPinPUD'] != '':
+                        self._logger.warning("Kernel version 5.5 or greater required for GPIO bias. Using 'default'.")
+                    bias = "default"
+                elif self.config['senseGPIOPinPUD'] == '':
+                    bias = "disable"
+                elif self.config['senseGPIOPinPUD'] == 'PULL_UP':
+                    bias = "pull_up"
+                elif self.config['senseGPIOPinPUD'] == 'PULL_DOWN':
+                    bias = "pull_down"
+                else:
+                    bias = "default"
+
+                try:
+                    pin = periphery.CdevGPIO(path=self.config['GPIODevice'], line=self.config['senseGPIOPin'], direction='in', bias=bias)
+                    self._configuredGPIOPins['sense'] = pin
+                except Exception:
+                    self._logger.exception(
+                        "Exception while setting up GPIO pin {}".format(self.config['senseGPIOPin'])
+                    )
 
 
     def _get_plugin_key(self, implementation):

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -64,7 +64,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
         self._idleTimer = None
         self._waitForHeaters = False
         self._skipIdleTimer = False
-        self._configuredGPIOPins: Dict[str, periphery.CdevGPIO] = {}
+        self._configuredGPIOPins = {}
         self._noSensing_isPSUOn = False
         self.isPSUOn = False
 

--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -187,7 +187,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
                     path=self.config['GPIODevice'],
                     line=self.config['onoffGPIOPin'],
                     direction="out",
-                    inverted=self.config['invertonoffGPIOPin']
+                    inverted=not self.config['invertonoffGPIOPin']  # TODO: this looks fishy
                 )
             except Exception:
                 self._logger.exception(


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

The changes allow to re-use the switching GPIO for sensing the current on/off state.
This addresses #182.

#### How was it tested? How can it be tested by the reviewer?

Tested on my personal setup, which uses a Raspberry 4 and pulls GPIO 2 to GND for switching the printer on:
![circuit drawio](https://user-images.githubusercontent.com/39721804/132185929-95c0340e-2a8c-4c5b-8ef9-2149810e6a78.png)

Further testing on other setups is needed, but I only have the one printer.


#### What are the relevant tickets if any?
#182

#### Further notes

* The changes also clean up some inconsistencies in the code between the sensing and switching pin (both use `CdevGPIO` now).
* The changes use the `inverted`-parameter of `CdevGPIO` to remove a lot of manual handling of inverted pin logic.
* See this PR as a starting point. I would highly suggest to do some refactoring and splitting up the logic for each switching and sensing method. However, I did not want to put a lot of energy into that without knowing whether you would actually be interested.
