### PR TITLE
Adding an option "Post Connect Delay"

### DIFF
--- a/octoprint_psucontrol/__init__.py
+++ b/octoprint_psucontrol/__init__.py
@@ -84,6 +84,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
             pseudoOnGCodeCommand = 'M80',
             pseudoOffGCodeCommand = 'M81',
             postOnDelay = 0.0,
+            postConnectDelay = 0.0,
             connectOnPowerOn = False,
             disconnectOnPowerOff = False,
             sensingMethod = 'INTERNAL',
@@ -511,7 +512,7 @@ class PSUControl(octoprint.plugin.StartupPlugin,
 
             if self.config['connectOnPowerOn'] and self._printer.is_closed_or_error():
                 self._printer.connect()
-                time.sleep(0.1)
+                time.sleep(0.1 + self.config['postConnectDelay'])
 
             if not self._printer.is_closed_or_error():
                 self._printer.script("psucontrol_post_on", must_be_set=False)

--- a/octoprint_psucontrol/templates/psucontrol_settings.jinja2
+++ b/octoprint_psucontrol/templates/psucontrol_settings.jinja2
@@ -219,6 +219,17 @@
             </label>
         </div>
     </div>
+    <!-- ko if: settings.plugins.psucontrol.connectOnPowerOn() -->
+    <div class="control-group">
+        <label class="control-label">Post Connect Delay</label>
+        <div class="controls">
+            <div class="input-append">
+                <input type="number" min="0" step="0.1" class="input-mini text-right" data-bind="value: settings.plugins.psucontrol.postConnectDelay">
+                <span class="add-on">sec</span>
+            </div>
+        </div>
+    </div>
+    <!-- /ko -->
     <div class="control-group">
         <div class="controls">
             <label class="checkbox">


### PR DESCRIPTION
Thank you for your interest into contributing to OctoPrint-PSUControl, it's highly appreciated!

Before submitting please make sure you have ticked all points on this checklist:

  * [x] Your PR targets the devel branch.
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style.
  * [x] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?
I'd summarize as:
Adding an option "Post Connect Delay" same as and kinda copied from "Post On Delay" but after connecting to the printer to give Octoprint time to get fully connected before continuing its work (like trying to start a print)

This solves the issue with not starting a print after powering on the printer via PSU control due to connecting not being fast enough.
https://community.octoprint.org/t/automatically-start-printing-after-turning-on-via-psu-controll-after-api-upload/43030/11

#### How was it tested? How can it be tested by the reviewer?
I just copied the two files from this repo to my local setup and run it. Worked as supposed.

#### Any background context you want to provide?
#### What are the relevant tickets if any?
#### Further notes
Take a look at:
https://community.octoprint.org/t/automatically-start-printing-after-turning-on-via-psu-controll-after-api-upload/43030/11

#### Screenshots (if appropriate)
n/a


