### PR TITLE
Set GPIOD consumer label for when pins are requested

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -15,7 +15,9 @@ All support related questions will be closed.
 Feature requests should be made at:
 https://feathub.com/kantlivelong/OctoPrint-PSUControl
 
-When reporting a bug do NOT delete ANY lines from the template.
+When reporting a bug do NOT delete ANY lines from the template or exclude 
+any information unless otherwise noted.
+Failure to follow this will result in the ticket being closed and locked.
 
 Make sure any bug you want to report is still present with the CURRENT
 OctoPrint-PSUControl version.


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Sets the GPIOD label (consumer field) when requesting GPIO pins with periphery; by default the pin consumer is set to `periphery` while the pin is used. This change simply sets the consumer message to `octoprint-[NAME]` where 'NAME' is the printer name from the main OctoPrint settings.

#### How was it tested? How can it be tested by the reviewer?
Tested locally on my system, this trivial enough (arguments added on just two lines) that it can be reviewed and tested on any GPIOD enabled instance. Use `gpioinfo | grep "\[used\]"` to see the current list of used pins, status and consumer strings 

#### Notes ####
This is trivial, and this plugin is currently stalled, but if anybody works on it again this would be a 'nice to have' change.

This is the result on my install
```
daisy@pi:~ $ gpioinfo /dev/gpiochip0 | grep line\ *8
	line   8:      "GPIO8" "periphery" output active-high [used]
```
becomes:
```
daisy@pi:~ $ gpioinfo /dev/gpiochip0 | grep line\ *8
	line   8:      "GPIO8" "octoprint-Daisy" output active-high [used]
```